### PR TITLE
refactor: remove unused setup function

### DIFF
--- a/lua/midnight/init.lua
+++ b/lua/midnight/init.lua
@@ -1,14 +1,5 @@
 local M = {}
 
----@class MidnightConfig
----@field [string] any
-
----@param opts? MidnightConfig
----@return nil
-function M.setup(opts)
-  opts = opts or {}
-end
-
 ---@return nil
 function M.load()
   if vim.g.colors_name then


### PR DESCRIPTION
## Summary
- Remove the no-op `setup()` function that accepts options but does nothing with them

Colorschemes don't need configuration via setup() since they load through `:colorscheme midnight`.