### PR TITLE
fix: add deprecation warning for setup()

### DIFF
--- a/lua/midnight/init.lua
+++ b/lua/midnight/init.lua
@@ -18,7 +18,7 @@ function M.load()
 end
 
 ---@deprecated Use `vim.cmd('colorscheme midnight')` instead
-function M.setup(opts)
+function M.setup(_opts)
   vim.deprecate(
     'require("midnight").setup()',
     'vim.cmd("colorscheme midnight")',


### PR DESCRIPTION
Adds back the `setup()` function with a deprecation warning so existing users get a clear migration path instead of an error.