### PR TITLE
revert(ci): restore GitHub-hosted runners

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish-luarocks:
     name: Publish to LuaRocks
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Publish to LuaRocks

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}
@@ -33,7 +33,7 @@ jobs:
 
   lua-format:
     name: Lua Format Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   lua-lint:
     name: Lua Lint Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   lua-typecheck:
     name: Lua Type Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   vimdoc-check:
     name: Vimdoc Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
@@ -77,7 +77,7 @@ jobs:
 
   markdown-format:
     name: Markdown Format Check
-    runs-on: [self-hosted, linux, x64, netcup, general]
+    runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:


### PR DESCRIPTION
## Summary
- revert the self-hosted runner migration
- restore GitHub-hosted workflow execution for this repo
- remove the netcup runner dependency from CI

#### Test plan
- [x] Confirmed the revert removes `self-hosted` from the workflow files