### PR TITLE
build: replace prettier with biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
     "includes": [
       "**",
       "!**/.pytest_cache/",
+      "!**/.direnv/",
       "!**/node_modules/",
       "!**/.venv/",
       "!**/build/",
@@ -24,6 +25,15 @@
       "quoteStyle": "single",
       "trailingCommas": "none",
       "semicolons": "asNeeded"
+    }
+  },
+  "json": {
+    "formatter": {
+      "indentStyle": "space",
+      "indentWidth": 2,
+      "lineEnding": "lf",
+      "lineWidth": 80,
+      "trailingCommas": "none"
     }
   }
 }

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    biome format .
+    git ls-files -z | xargs -0 biome format
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet


### PR DESCRIPTION
Replace Prettier with Biome in the repo's format workflow and Nix shells. This removes the Prettier config files, adds a Biome config with the repo's ignore patterns and JSON formatting settings, and updates just format to use Biome.

Verified with the repo's Nix and just workflows: just format, just lint, and the ci shell running just ci in /tmp/midnight.nvim/replace-prettier-with-biome.